### PR TITLE
Only use django jQuery

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -82,4 +82,4 @@
             }
         });
     });
-}(jQuery || django.jQuery));
+}(django.jQuery));

--- a/smart_selects/static/smart-selects/admin/js/chainedfk.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedfk.js
@@ -110,4 +110,4 @@
             }
         };
     }());
-}(jQuery || django.jQuery));
+}(django.jQuery));

--- a/smart_selects/static/smart-selects/admin/js/chainedm2m.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedm2m.js
@@ -177,4 +177,4 @@
             }
         };
     }());
-}(jQuery || django.jQuery));
+}(django.jQuery));


### PR DESCRIPTION
The `bindfields.js` seems to fail to receive the `formset:added` event, probably because those events are triggered using the `django.jQuery`.
https://docs.djangoproject.com/en/1.11/ref/contrib/admin/javascript/#inline-form-events
