### PR TITLE
Force to load select2 js first

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -204,13 +204,16 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
     def media(self):
         """Media defined as a dynamic property instead of an inner class."""
         media = super(ChainedSelectMultiple, self).media
-        js = ['smart-selects/admin/js/chainedm2m.js',
-              'smart-selects/admin/js/bindfields.js']
+        js = []
         if self.horizontal:
             # For horizontal mode add django filter horizontal javascript code
             js.extend(["admin/js/core.js",
                        "admin/js/SelectBox.js",
                        "admin/js/SelectFilter2.js"])
+        js.extend([
+            'smart-selects/admin/js/chainedm2m.js',
+            'smart-selects/admin/js/bindfields.js'
+        ])
         media += Media(js=js)
         return media
 


### PR DESCRIPTION
Fix the `ManyToMany` field when `horizontal=True` by making sure the `SelectFilter2` is loaded first.