### PR TITLE
Avoid double values when using horizontal=True

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/chainedm2m.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedm2m.js
@@ -45,17 +45,6 @@
                     }
                 }
 
-                // SelectBox is a global var from djangojs "admin/js/SelectBox.js"
-                // Clear cache to avoid the elements duplication
-                if (typeof SelectBox !== 'undefined') {
-                    if (typeof SelectBox.cache[cache_to] !== 'undefined') {
-                        SelectBox.cache[cache_to].splice(0);
-                    }
-                    if (typeof SelectBox.cache[cache_from] !== 'undefined') {
-                        SelectBox.cache[cache_from].splice(0);
-                    }
-                }
-
                 if (!val || val === '') {
                     $selectField.html('');
                     $selectedto.html('');
@@ -111,6 +100,18 @@
                     });
 
                     $selectField.html(options);
+
+                    // SelectBox is a global var from djangojs "admin/js/SelectBox.js"
+                    // Clear cache to avoid the elements duplication
+                    if (typeof SelectBox !== 'undefined') {
+                        if (typeof SelectBox.cache[cache_to] !== 'undefined') {
+                            SelectBox.cache[cache_to].splice(0);
+                        }
+                        if (typeof SelectBox.cache[cache_from] !== 'undefined') {
+                            SelectBox.cache[cache_from].splice(0);
+                        }
+                    }
+
                     if ($selectedto.length) {
                         $selectedto.html(selectedoptions);
                         // SelectBox is a global var from djangojs "admin/js/SelectBox.js"


### PR DESCRIPTION
For some reasons, when using `horizontal=True`, the `change` event is triggered twice, and so is the API request to retrieve the values.

The result is that the `_from` SelectBox is filled with twice the same values. 

Moving the reset of the SelectBox cache from within the API request `.then()` method works around the issue.

Not entirely sure if it needed to be outside for anything. Please test before merging