### PR TITLE
Init horizontal filtered on load

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/bindfields.js
+++ b/smart_selects/static/smart-selects/admin/js/bindfields.js
@@ -24,6 +24,11 @@
         $.each($(".chained"), function (index, item) {
             initItem(item);
         });
+        $.each($(".filtered"), function (index, item) {
+            if (item.hasAttribute('data-chainfield')) {
+                initItem(item);
+            }
+        });
     });
 
     $(document).ready(function () {


### PR DESCRIPTION
After https://github.com/jazzband/django-smart-selects/pull/273 was merged, in latest django (3.0.6) I'm not getting any events fired in `bindfields.js` when using `ManyToMany` fields with `horizontal=True`. This is because the `initItem` is not called on `.filtered` class on load
