### PR TITLE
Reverting excessive lint correction that breaks init_value check

### DIFF
--- a/smart_selects/static/smart-selects/admin/js/chainedfk.js
+++ b/smart_selects/static/smart-selects/admin/js/chainedfk.js
@@ -64,7 +64,7 @@
                         } else if (auto_choose === "false" || auto_choose === "False") {
                             auto_choose = false;
                         }
-                        if (auto_choose || (init_value && optionData.value === init_value)) {
+                        if (auto_choose || (init_value && optionData.value == init_value)) {
                             option.prop('selected', true);
                         }
                         options.push(option);


### PR DESCRIPTION
When comparing init_value with fetched data the var type may have changed due to html.val() assignment (always string), so it will never match the previously selected option. Using only == will fix this issue.

Didn't check yet if the same issues applies to the many-to-many script.