### PR TITLE
Change force_text to force_str to remove RemoveInDjango40Warning

### DIFF
--- a/smart_selects/form_fields.py
+++ b/smart_selects/form_fields.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.forms.models import ModelChoiceField, ModelMultipleChoiceField
 from django.forms import ChoiceField
 from smart_selects.widgets import ChainedSelect, ChainedSelectMultiple
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 get_model = apps.get_model
 
@@ -77,7 +77,7 @@ class GroupedModelSelect(ModelChoiceField):
             group_index = order_field.pk
             if group_index not in group_indexes:
                 group_indexes[group_index] = i
-                choices.append([force_text(order_field), []])
+                choices.append([force_str(order_field), []])
                 i += 1
             choice_index = group_indexes[group_index]
             choices[choice_index][1].append(self.make_choice(item))

--- a/smart_selects/utils.py
+++ b/smart_selects/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import django
 from django.apps import apps
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 get_model = apps.get_model
 
@@ -52,7 +52,7 @@ def get_queryset(model_class, manager=None, limit_choices_to=None):
 
 def serialize_results(results):
     return [
-        {'value': item.pk if str(item.pk).isdigit() else str(item.pk), 'display': force_text(item)} for item in results
+        {'value': item.pk if str(item.pk).isdigit() else str(item.pk), 'display': force_str(item)} for item in results
     ]
 
 
@@ -70,4 +70,4 @@ def get_keywords(field, value, m2m=False):
 def sort_results(results):
     """Performs in-place sort of filterchain results."""
 
-    results.sort(key=lambda x: unicode_sorter(force_text(x)))
+    results.sort(key=lambda x: unicode_sorter(force_str(x)))

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -253,7 +253,7 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
 
         attrs["data-chainfield"] = chain_field
         attrs["data-url"] = url
-        attrs["data-value"] = "null" if value is None else json.dumps(force_str(value))
+        attrs["data-value"] = "null" if value is None else json.dumps(value)
         attrs["data-auto_choose"] = auto_choose
         attrs["name"] = name
         final_attrs = self.build_attrs(attrs)

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -1,9 +1,9 @@
 import json
 
 import django
-
 from django.apps import apps
 from django.conf import settings
+
 try:
     from django.core.urlresolvers import reverse
 except ImportError:
@@ -11,7 +11,7 @@ except ImportError:
     from django.urls import reverse
 from django.forms.widgets import Select, SelectMultiple, Media
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_str, force_text
+from django.utils.encoding import force_str
 from django.utils.html import escape
 
 from smart_selects.utils import unicode_sorter, sort_results
@@ -101,7 +101,7 @@ class ChainedSelect(JqueryMediaMixin, Select):
             'foreign_key_model_name': self.foreign_key_model_name,
             'foreign_key_field_name': self.foreign_key_field_name,
             'value': '1'
-            }
+        }
         if self.manager is not None:
             kwargs.update({'manager': self.manager})
         url = URL_PREFIX + ("/".join(reverse(view_name, kwargs=kwargs).split("/")[:-2]))
@@ -253,7 +253,7 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
 
         attrs["data-chainfield"] = chain_field
         attrs["data-url"] = url
-        attrs["data-value"] = "null" if value is None else json.dumps(force_text(value))
+        attrs["data-value"] = "null" if value is None else json.dumps(force_str(value))
         attrs["data-auto_choose"] = auto_choose
         attrs["name"] = name
         final_attrs = self.build_attrs(attrs)

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -11,7 +11,7 @@ except ImportError:
     from django.urls import reverse
 from django.forms.widgets import Select, SelectMultiple, Media
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str, force_text
 from django.utils.html import escape
 
 from smart_selects.utils import unicode_sorter, sort_results
@@ -124,7 +124,7 @@ class ChainedSelect(JqueryMediaMixin, Select):
         if value:
             available_choices = self._get_available_choices(self.queryset, value)
             for choice in available_choices:
-                final_choices.append((choice.pk, force_text(choice)))
+                final_choices.append((choice.pk, force_str(choice)))
         if len(final_choices) > 1:
             final_choices = [("", (empty_label))] + final_choices
         if self.show_all:
@@ -253,7 +253,7 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
 
         attrs["data-chainfield"] = chain_field
         attrs["data-url"] = url
-        attrs["data-value"] = "null" if value is None else json.dumps(value)
+        attrs["data-value"] = "null" if value is None else json.dumps(force_text(value))
         attrs["data-auto_choose"] = auto_choose
         attrs["name"] = name
         final_attrs = self.build_attrs(attrs)


### PR DESCRIPTION
Change force_text to force_str to remove RemoveInDjango40Warning 

```
.../smart_selects/utils.py:73: RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().
  results.sort(key=lambda x: unicode_sorter(force_text(x)))
.../smart_selects/utils.py:55: RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().
  {'value': item.pk if str(item.pk).isdigit() else str(item.pk), 'display': force_text(item)} for item in results
```