### PR TITLE
Django 3.1 deprecation warnings

### DIFF
--- a/smart_selects/form_fields.py
+++ b/smart_selects/form_fields.py
@@ -2,7 +2,7 @@ from django.apps import apps
 from django.forms.models import ModelChoiceField, ModelMultipleChoiceField
 from django.forms import ChoiceField
 from smart_selects.widgets import ChainedSelect, ChainedSelectMultiple
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 get_model = apps.get_model
 
@@ -77,7 +77,7 @@ class GroupedModelSelect(ModelChoiceField):
             group_index = order_field.pk
             if group_index not in group_indexes:
                 group_indexes[group_index] = i
-                choices.append([force_text(order_field), []])
+                choices.append([force_str(order_field), []])
                 i += 1
             choice_index = group_indexes[group_index]
             choices[choice_index][1].append(self.make_choice(item))

--- a/smart_selects/urls.py
+++ b/smart_selects/urls.py
@@ -1,14 +1,11 @@
 from smart_selects import views
-try:
-    from django.conf.urls.defaults import url
-except ImportError:
-    from django.conf.urls import url
+from django.conf.urls import re_path
 
 urlpatterns = [
-    url(r'^all/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',  # noqa: E501
+    re_path(r'^all/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',  # noqa: E501
         views.filterchain_all, name='chained_filter_all'),
-    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',  # noqa: E501
+    re_path(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',  # noqa: E501
         views.filterchain, name='chained_filter'),
-    url(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',  # noqa: E501
+    re_path(r'^filter/(?P<app>[\w\-]+)/(?P<model>[\w\-]+)/(?P<manager>[\w\-]+)/(?P<field>[\w\-]+)/(?P<foreign_key_app_name>[\w\-]+)/(?P<foreign_key_model_name>[\w\-]+)/(?P<foreign_key_field_name>[\w\-]+)/(?P<value>[\w\-,]+)/$',  # noqa: E501
         views.filterchain, name='chained_filter'),
 ]

--- a/smart_selects/utils.py
+++ b/smart_selects/utils.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import django
 from django.apps import apps
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 get_model = apps.get_model
 
@@ -52,7 +52,7 @@ def get_queryset(model_class, manager=None, limit_choices_to=None):
 
 def serialize_results(results):
     return [
-        {'value': item.pk if str(item.pk).isdigit() else str(item.pk), 'display': force_text(item)} for item in results
+        {'value': item.pk if str(item.pk).isdigit() else str(item.pk), 'display': force_str(item)} for item in results
     ]
 
 
@@ -70,4 +70,4 @@ def get_keywords(field, value, m2m=False):
 def sort_results(results):
     """Performs in-place sort of filterchain results."""
 
-    results.sort(key=lambda x: unicode_sorter(force_text(x)))
+    results.sort(key=lambda x: unicode_sorter(force_str(x)))

--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -11,7 +11,7 @@ except ImportError:
     from django.urls import reverse
 from django.forms.widgets import Select, SelectMultiple, Media
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.html import escape
 
 from smart_selects.utils import unicode_sorter, sort_results
@@ -124,7 +124,7 @@ class ChainedSelect(JqueryMediaMixin, Select):
         if value:
             available_choices = self._get_available_choices(self.queryset, value)
             for choice in available_choices:
-                final_choices.append((choice.pk, force_text(choice)))
+                final_choices.append((choice.pk, force_str(choice)))
         if len(final_choices) > 1:
             final_choices = [("", (empty_label))] + final_choices
         if self.show_all:

--- a/test_app/urls.py
+++ b/test_app/urls.py
@@ -1,10 +1,10 @@
 import django
-from django.conf.urls import include, url
 from django.contrib import admin
+from django.urls import include, path
 
 
 urlpatterns = [
-    (url(r'^admin/', include(admin.site.urls)) if django.VERSION < (2, 0)
-     else url(r'^admin/', admin.site.urls)),
-    url(r'^chaining/', include('smart_selects.urls')),
+    (path('admin/', include(admin.site.urls)) if django.VERSION < (2, 0)
+     else path('admin/', admin.site.urls)),
+    path('chaining/', include('smart_selects.urls')),
 ]


### PR DESCRIPTION
A few tidy ups following the release of Django 3.1

- url() is deprecated in favor of path() and re_path()
- force_text is deprecated in favor of force_str()