### PR TITLE
ChainedSelectMultiple widget doesnt update css on override

### DIFF
--- a/smart_selects/widgets.py
+++ b/smart_selects/widgets.py
@@ -300,6 +300,7 @@ class ChainedSelectMultiple(JqueryMediaMixin, SelectMultiple):
         final_choices = []
         self.choices = final_choices
 
+        attrs.update(self.attrs)
         attrs["data-chainfield"] = chain_field
         attrs["data-url"] = url
         attrs["data-value"] = "null" if value is None else json.dumps(value)


### PR DESCRIPTION
ChainedSelectMultiple doesn't update de css extra attrs 
attrs.update(self.attrs)##< this is missing
attrs["data-chainfield"] = chain_field
attrs["data-url"] = url